### PR TITLE
Update gala-0.1_p20141221.ebuild

### DIFF
--- a/x11-wm/gala/gala-0.1_p20141221.ebuild
+++ b/x11-wm/gala/gala-0.1_p20141221.ebuild
@@ -10,7 +10,7 @@ inherit gnome2-utils vala autotools-utils
 
 DESCRIPTION="Pantheon's Window Manager"
 HOMEPAGE="https://launchpad.net/gala"
-SRC_URI="https://launchpad.net/~elementary-os/+archive/ubuntu/daily/+files/gala_0.1.0%7Er426%2Bpkg29%7Eubuntu14.10.1.tar.xz"
+SRC_URI="https://launchpad.net/~elementary-os/+archive/ubuntu/daily/+files/gala_0.1.0%7Er431%2Bpkg29%7Eubuntu14.10.1.tar.xz"
 
 LICENSE="GPL-3"
 SLOT="0"
@@ -36,7 +36,7 @@ AUTOTOOLS_AUTORECONF=1
 src_unpack() {
 	default_src_unpack
 
-	mv "${WORKDIR}/gala-0.1.0~r426+pkg29~ubuntu14.10.1" "${S}"
+	mv "${WORKDIR}/gala-0.1.0~r431+pkg29~ubuntu14.10.1" "${S}"
 }
 
 src_prepare() {


### PR DESCRIPTION
I changed the url and the extraction process accordingly so gala can be downloaded again.